### PR TITLE
Fixes for 5x5 logic near edges

### DIFF
--- a/tglc/target_lightcurve.py
+++ b/tglc/target_lightcurve.py
@@ -359,7 +359,7 @@ def epsf(source, psf_size=11, factor=2, local_directory='', target=None, cut_x=0
                               bg=background_, time=source.time, psf_lc=psf_lc, cal_psf_lc=cal_psf_lc, aper_lc=aper_lc,
                               cal_aper_lc=cal_aper_lc, local_bg=local_bg, x_aperture=x_aperture[i],
                               y_aperture=y_aperture[i], near_edge=near_edge, save_aper=save_aper, portion=portion,
-                              prior=prior)
+                              prior=prior, transient=source.transient, target_5x5=target_5x5, field_stars_5x5=field_stars_5x5)
                 else:
                     lc_output(source, local_directory=lc_directory, index=i,
                               tess_flag=source.quality, cut_x=cut_x, cut_y=cut_y, cadence=source.cadence,


### PR DESCRIPTION
I uncovered some edge cases where simulated 5x5 image around a target were not being handled correctly near edges. The most significant change is padding the `target_5x5` and `field_stars_5x5` arrays with nans when necessary; these are used to estimate the contamination ratio and end up in the image HDU (HDU 2) in the light curve FITS file.

Note: I have not tested these changes extensively, but they worked in the scenario I was testing.