### PR TITLE
Release 0.7.1: MAST/Gaia resilience + non-TTY spinner fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.1
+- Spinner in `_dot_wait` now detects non-TTY stdout (PyCharm run console, pipes, CI logs) and prints a single line per call instead of repeating the `\r` animation.
+- Gaia DR3 cone search in `ffi_cut` falls back to the MAST Gaia (DR2) catalog when the Gaia TAP is unavailable.
+- `convert_gaia_id` (DR2 → DR3 crossmatch) falls back to `catalogdata_tic['GAIA']` on Gaia TAP failure so the pipeline survives archive outages.
+- `effective_psf` builds 5×5 cutouts by indexing into a preallocated NaN array (safer near FFI edges).
+- `lc_output` default `ffi` is now `'SPOC'`.
+
 ## 0.7.0
 - Updated dependencies for modern Python/astropy compatibility.
 - Added `importlib_resources` and improved package data loading.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 setuptools.setup(
     name="tglc",
-    version='0.7.0',
+    version='0.7.1',
     author="Te Han",
     author_email="tehanhunter@gmail.com",
     description="TESS-Gaia Light Curve",

--- a/tglc/effective_psf.py
+++ b/tglc/effective_psf.py
@@ -202,17 +202,16 @@ def fit_lc(A, source, star_info=None, x=0., y=0., star_num=0, factor=2, psf_size
     for j in range(len(source.time)):
         aperture[j] = np.array(source.flux[j][down:up, left:right]).flatten() - np.dot(A_cut, e_psf[j])
     aperture = aperture.reshape((len(source.time), up - down, right - left))
-    target_5x5 = (np.dot(A_target, np.nanmedian(e_psf, axis=0)).reshape(cut_size, cut_size))
-    field_stars_5x5 = (np.dot(A_cut, np.nanmedian(e_psf, axis=0)).reshape(cut_size, cut_size))
-    if target_5x5.shape != (cut_size, cut_size):
-        # Pad with nans to get to 5x5 shape
-        # Pad amount in a direction is (expected_num_pix) - (actual_num_pix)
-        pad_left = (cut_size // 2) - (x - left)
-        pad_right = (cut_size // 2 + 1) - (right - x)
-        pad_down = (cut_size // 2) - (y - down)
-        pad_up = (cut_size // 2 + 1) - (up - y)
-        target_5x5 = np.pad(target_5x5, [(pad_down, pad_up), (pad_left, pad_right)], constant_values=np.nan)
-        field_stars_5x5 = np.pad(field_stars_5x5, [(pad_down, pad_up), (pad_left, pad_right)], constant_values=np.nan)
+    h = up - down
+    w = right - left
+    target_plane = np.dot(A_target, np.nanmedian(e_psf, axis=0)).reshape(h, w)
+    field_plane = np.dot(A_cut, np.nanmedian(e_psf, axis=0)).reshape(h, w)
+    target_5x5 = np.full((cut_size, cut_size), np.nan)
+    field_stars_5x5 = np.full((cut_size, cut_size), np.nan)
+    y0 = int(down - y + cut_size // 2)
+    x0 = int(left - x + cut_size // 2)
+    target_5x5[y0:y0 + h, x0:x0 + w] = target_plane
+    field_stars_5x5[y0:y0 + h, x0:x0 + w] = field_plane
 
     # psf_lc
     over_size = psf_size * factor + 1
@@ -470,7 +469,7 @@ def bg_mod(source, q=None, aper_lc=None, psf_lc=None, portion=None, star_num=0, 
         print('Calibrated aperture flux are not accessible or processed incorrectly. ')
     else:
         _, trend = flatten(source.time, cal_aper_lc - np.nanmin(cal_aper_lc) + 1000,
-                                    window_length=1, method='biweight', return_trend=True)
+                           window_length=1, method='biweight', return_trend=True)
         cal_aper_lc = (cal_aper_lc - np.nanmin(cal_aper_lc) + 1000 - trend) / np.nanmedian(cal_aper_lc) + 1
         # cal_aper_lc = flatten(source.time, cal_aper_lc, window_length=1, method='biweight',
         #                       return_trend=False)
@@ -484,7 +483,7 @@ def bg_mod(source, q=None, aper_lc=None, psf_lc=None, portion=None, star_num=0, 
             print('Calibrated PSF flux are not accessible or processed incorrectly. ')
         else:
             _, trend = flatten(source.time, cal_psf_lc - np.nanmin(cal_psf_lc) + 1000,
-                                         window_length=1, method='biweight', return_trend=True)
+                               window_length=1, method='biweight', return_trend=True)
             cal_psf_lc = (cal_psf_lc - np.nanmin(cal_psf_lc) + 1000 - trend) / np.nanmedian(cal_psf_lc) + 1
             # cal_psf_lc = flatten(source.time, cal_psf_lc, window_length=1, method='biweight',
             #                      return_trend=False)

--- a/tglc/ffi.py
+++ b/tglc/ffi.py
@@ -2,6 +2,7 @@ import json
 import os
 import pickle
 import sys
+import warnings
 import astropy.units as u
 import numpy as np
 import importlib_resources
@@ -90,19 +91,30 @@ def convert_gaia_id(catalogdata_tic):
     gaia_array = gaia_array[gaia_array != 'None']
     # np.save('gaia_array.npy', gaia_array)
     segment = (len(gaia_array) - 1) // 10000
-    gaia_tuple = tuple(gaia_array[:10000])
-    results = Gaia.launch_job_async(query.format(gaia_ids=gaia_tuple)).get_results()
-    # np.save('result.npy', np.array(results))
-    for i in range(segment):
-        gaia_array_cut = gaia_array[((i+1)*10000):((i+2)*10000)]
-        gaia_tuple_cut = tuple(gaia_array_cut)
-        results = vstack([results, Gaia.launch_job_async(query.format(gaia_ids=gaia_tuple_cut)).get_results()])
-    tic_ids = []
-    for j in range(len(results)):
-        tic_ids.append(int(catalogdata_tic['ID'][np.where(catalogdata_tic['GAIA'] == str(results['dr2_source_id'][j]))][0]))
-    tic_ids = Column(np.array(tic_ids), name='TIC')
-    results.add_column(tic_ids)
-    return results
+    try:
+        gaia_tuple = tuple(gaia_array[:10000])
+        results = Gaia.launch_job_async(query.format(gaia_ids=gaia_tuple)).get_results()
+        # np.save('result.npy', np.array(results))
+        for i in range(segment):
+            gaia_array_cut = gaia_array[((i+1)*10000):((i+2)*10000)]
+            gaia_tuple_cut = tuple(gaia_array_cut)
+            results = vstack([results, Gaia.launch_job_async(query.format(gaia_ids=gaia_tuple_cut)).get_results()])
+        tic_ids = []
+        for j in range(len(results)):
+            tic_ids.append(int(catalogdata_tic['ID'][np.where(catalogdata_tic['GAIA'] == str(results['dr2_source_id'][j]))][0]))
+        tic_ids = Column(np.array(tic_ids), name='TIC')
+        results.add_column(tic_ids)
+        return results
+    except Exception as exc:
+        warnings.warn(
+            f'Gaia DR2->DR3 crossmatch failed ({exc}). Falling back to TIC catalog GAIA (DR2) identifiers.'
+        )
+        valid = np.array(catalogdata_tic['GAIA']) != 'None'
+        results = Table()
+        results['dr2_source_id'] = np.array(catalogdata_tic['GAIA'][valid], dtype=np.int64)
+        results['dr3_source_id'] = np.array(catalogdata_tic['GAIA'][valid], dtype=np.int64)
+        results['TIC'] = np.array(catalogdata_tic['ID'][valid], dtype=np.int64)
+        return results
 
 
 # from Tim

--- a/tglc/ffi_cut.py
+++ b/tglc/ffi_cut.py
@@ -30,6 +30,7 @@ Gaia.MAIN_GAIA_TABLE = "gaiadr3.gaia_source"
 def _dot_wait(message, interval=0.6, done_format=None):
     stop_event = threading.Event()
     start = time.time()
+    is_tty = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
 
     def _run():
         dots = 0
@@ -38,17 +39,23 @@ def _dot_wait(message, interval=0.6, done_format=None):
             print(f"\r{message} {'.' * dots}", end="", flush=True)
             time.sleep(interval)
 
-    thread = threading.Thread(target=_run, daemon=True)
-    thread.start()
+    if is_tty:
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+    else:
+        print(f"{message} ...", flush=True)
+        thread = None
     try:
         yield
     finally:
         stop_event.set()
-        thread.join()
+        if thread is not None:
+            thread.join()
         if done_format is None:
             done_format = "{message} ... done in {elapsed:.1f}s."
         done_line = done_format.format(message=message, elapsed=time.time() - start)
-        print(f"\r{done_line}   ")
+        prefix = "\r" if is_tty else ""
+        print(f"{prefix}{done_line}   ")
 
 
 class Source_cut(object):
@@ -131,14 +138,24 @@ class Source_cut(object):
         radius = u.Quantity((self.size + 6) * 21 * 0.707 / 3600, u.deg)
         if target_designation:
             print(f'Target Gaia: {target_designation}')
-        with _dot_wait('Querying Gaia DR3 cone search'):
-            catalogdata = Gaia.cone_search_async(
-                coord,
-                radius=radius,
-                columns=['DESIGNATION', 'phot_g_mean_mag', 'phot_bp_mean_mag',
-                         'phot_rp_mean_mag', 'ra', 'dec', 'pmra', 'pmdec']
-            ).get_results()
-        print(f'Found {len(catalogdata)} Gaia DR3 objects.')
+        try:
+            with _dot_wait('Querying Gaia DR3 cone search'):
+                catalogdata = Gaia.cone_search_async(
+                    coord,
+                    radius=radius,
+                    columns=['DESIGNATION', 'phot_g_mean_mag', 'phot_bp_mean_mag',
+                             'phot_rp_mean_mag', 'ra', 'dec', 'pmra', 'pmdec']
+                ).get_results()
+            print(f'Found {len(catalogdata)} Gaia DR3 objects.')
+        except Exception as exc:
+            warnings.warn(
+                f'Gaia DR3 cone search failed ({exc}). Falling back to MAST Gaia catalog (DR2).'
+            )
+            with _dot_wait('Querying Gaia catalog from MAST'):
+                catalogdata = Catalogs.query_region(coord, radius=radius, catalog='Gaia', version=2)
+            if 'designation' in catalogdata.colnames and 'DESIGNATION' not in catalogdata.colnames:
+                catalogdata.rename_column('designation', 'DESIGNATION')
+            print(f'Found {len(catalogdata)} Gaia objects from MAST fallback.')
         with _dot_wait('Querying TIC around target'):
             catalogdata_tic = tic_advanced_search_position_rows(
                 ra=ra,

--- a/tglc/target_lightcurve.py
+++ b/tglc/target_lightcurve.py
@@ -24,7 +24,8 @@ warnings.simplefilter('always', UserWarning)
 def lc_output(source, local_directory='', index=0, time=None, psf_lc=None, cal_psf_lc=None, aper_lc=None,
               cal_aper_lc=None, bg=None, tess_flag=None, tglc_flag=None, cadence=None, aperture=None,
               cut_x=None, cut_y=None, star_x=2, star_y=2, x_aperture=None, y_aperture=None, near_edge=False,
-              local_bg=None, save_aper=False, portion=1, prior=None, transient=None, target_5x5=None, field_stars_5x5=None, ffi='TICA'):
+              local_bg=None, save_aper=False, portion=1, prior=None, transient=None, target_5x5=None, field_stars_5x5=None,
+              ffi='SPOC'):
     """
     lc output to .FITS file in MAST HLSP standards
     :param tglc_flag: np.array(), required
@@ -336,6 +337,7 @@ def epsf(source, psf_size=11, factor=2, local_directory='', target=None, cut_x=0
                 aperture, psf_lc, star_y, star_x, portion = \
                     fit_lc_float_field(A, source, star_info=star_info, x=x_round, y=y_round, star_num=i, e_psf=e_psf,
                                        near_edge=near_edge, prior=prior)
+                target_5x5, field_stars_5x5 = None, None
             else:
                 aperture, psf_lc, star_y, star_x, portion, target_5x5, field_stars_5x5 = \
                     fit_lc(A, source, star_info=star_info, x=x_round[i], y=y_round[i], star_num=i, e_psf=e_psf,


### PR DESCRIPTION
## Summary
- `_dot_wait` spinner now detects non-TTY stdout (PyCharm run console, pipes, CI logs) — one line per call instead of dozens of `\r`-prefixed duplicates.
- `ffi_cut` Gaia DR3 cone search falls back to the MAST Gaia (DR2) catalog when the Gaia TAP is unavailable.
- `convert_gaia_id` (DR2 → DR3 crossmatch) falls back to `catalogdata_tic['GAIA']` on Gaia TAP failure so the pipeline survives archive outages.
- `effective_psf` builds 5×5 cutouts by indexing into a preallocated NaN array (safer near FFI edges).
- `lc_output` default `ffi` is now `'SPOC'`.
- `setup.py` bumped to `0.7.1`; `CHANGELOG.md` updated.

Scope deliberately excludes the personal analysis history on `lc_request` (plotting/BLS/phasebin scaffolding, per-target scripts) — shipped only the library-level resilience/bugfix changes.

## Test plan
- [x] Ran `scripts/quick_lc_smoketest.py` on `TIC 16005254`, sector 44, SPOC: FITS + plots produced, exit 0.
- [x] Verified spinner emits exactly one line per `_dot_wait` call in non-TTY stdout (count = 2: open + done).
- [ ] Optional: sanity-check `python -m build` produces a valid sdist/wheel before PyPI upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)