### PR TITLE
0.7.2: configurable Gaia TAP mirror fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.2
+- Added a configurable `gaia_tap_server` parameter to `tglc_lc`, `ffi_cut`, `Source_cut`, and `convert_gaia_id` so Gaia TAP queries can fall back to a user-specified mirror when the primary ESA server is down. Credit: Caleb Cañas (@cicanas).
+- `convert_gaia_id` now retries each 10k-ID batch against the mirror before giving up and using the TIC-GAIA (DR2) fallback.
+- `Source_cut` Gaia DR3 cone search retries via the mirror TAP endpoint before falling back to `Catalogs.query_region`.
+- `quick_lc` DR2→DR3 designation lookup collapsed to a single `gaia_source` ⨝ `dr2_neighbourhood` join (no intermediate `tmpgaiavals`), with mirror fallback.
+- `tglc.ffi_cut` exposes an optional `tesscube` import (guarded by `try/except ImportError`) in preparation for AWS-backed cutouts of `size > 99`.
+
 ## 0.7.1
 - Spinner in `_dot_wait` now detects non-TTY stdout (PyCharm run console, pipes, CI logs) and prints a single line per call instead of repeating the `\r` animation.
 - Gaia DR3 cone search in `ffi_cut` falls back to the MAST Gaia (DR2) catalog when the Gaia TAP is unavailable.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 setuptools.setup(
     name="tglc",
-    version='0.7.1',
+    version='0.7.2',
     author="Te Han",
     author_email="tehanhunter@gmail.com",
     description="TESS-Gaia Light Curve",

--- a/tglc/ffi.py
+++ b/tglc/ffi.py
@@ -16,6 +16,7 @@ from astropy.io import fits
 from astropy.table import Table, hstack, vstack, unique, Column
 from astropy.wcs import WCS
 from astroquery.gaia import Gaia
+from astroquery.utils.tap.core import TapPlus
 from scipy import ndimage
 from tqdm import tqdm, trange
 
@@ -81,24 +82,34 @@ def tic_advanced_search_position_rows(ra=1., dec=1., radius=0.5, limit_mag=16):
     return mast_json2table(out_data)
 
 
-def convert_gaia_id(catalogdata_tic):
+def convert_gaia_id(catalogdata_tic, gaia_tap_server="https://gea.esac.esa.int/tap-server/tap"):
     query = """
             SELECT dr2_source_id, dr3_source_id
             FROM gaiadr3.dr2_neighbourhood
             WHERE dr2_source_id IN {gaia_ids}
             """
+
+    def _run_query(gaia_tuple):
+        try:
+            return Gaia.launch_job_async(query.format(gaia_ids=gaia_tuple)).get_results()
+        except Exception as exc:
+            warnings.warn(
+                f'Primary Gaia TAP crossmatch failed ({exc}). Retrying via mirror {gaia_tap_server}.'
+            )
+            return TapPlus(url=gaia_tap_server).launch_job_async(
+                query.format(gaia_ids=gaia_tuple)
+            ).get_results()
+
     gaia_array = np.array([str(item) for item in catalogdata_tic['GAIA']], dtype=object)
     gaia_array = gaia_array[gaia_array != 'None']
-    # np.save('gaia_array.npy', gaia_array)
     segment = (len(gaia_array) - 1) // 10000
     try:
         gaia_tuple = tuple(gaia_array[:10000])
-        results = Gaia.launch_job_async(query.format(gaia_ids=gaia_tuple)).get_results()
-        # np.save('result.npy', np.array(results))
+        results = _run_query(gaia_tuple)
         for i in range(segment):
             gaia_array_cut = gaia_array[((i+1)*10000):((i+2)*10000)]
             gaia_tuple_cut = tuple(gaia_array_cut)
-            results = vstack([results, Gaia.launch_job_async(query.format(gaia_ids=gaia_tuple_cut)).get_results()])
+            results = vstack([results, _run_query(gaia_tuple_cut)])
         tic_ids = []
         for j in range(len(results)):
             tic_ids.append(int(catalogdata_tic['ID'][np.where(catalogdata_tic['GAIA'] == str(results['dr2_source_id'][j]))][0]))

--- a/tglc/ffi_cut.py
+++ b/tglc/ffi_cut.py
@@ -13,10 +13,16 @@ from os.path import exists
 from astroquery.gaia import Gaia
 from astroquery.mast import Tesscut
 from astroquery.mast import Catalogs
+from astroquery.utils.tap.core import TapPlus
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, hstack, Column
 from astropy.wcs import WCS
 from tglc.ffi import tic_advanced_search_position_rows, convert_gaia_id
+
+try:
+    from tesscube import TESSCube
+except ImportError:
+    TESSCube = None
 
 if not sys.warnoptions:
     warnings.simplefilter("ignore")
@@ -60,7 +66,7 @@ def _dot_wait(message, interval=0.6, done_format=None):
 
 class Source_cut(object):
     def __init__(self, name, size=50, sector=None, cadence=None, limit_mag=None, transient=None, ffi='TICA',
-                 mast_timeout=3600):
+                 mast_timeout=3600, gaia_tap_server="https://gea.esac.esa.int/tap-server/tap"):
         """
         Source_cut object that includes all data from TESS and Gaia DR3
         :param name: str, required
@@ -138,6 +144,7 @@ class Source_cut(object):
         radius = u.Quantity((self.size + 6) * 21 * 0.707 / 3600, u.deg)
         if target_designation:
             print(f'Target Gaia: {target_designation}')
+        catalogdata = None
         try:
             with _dot_wait('Querying Gaia DR3 cone search'):
                 catalogdata = Gaia.cone_search_async(
@@ -149,13 +156,33 @@ class Source_cut(object):
             print(f'Found {len(catalogdata)} Gaia DR3 objects.')
         except Exception as exc:
             warnings.warn(
-                f'Gaia DR3 cone search failed ({exc}). Falling back to MAST Gaia catalog (DR2).'
+                f'Primary Gaia DR3 cone search failed ({exc}). Retrying via mirror {gaia_tap_server}.'
             )
-            with _dot_wait('Querying Gaia catalog from MAST'):
-                catalogdata = Catalogs.query_region(coord, radius=radius, catalog='Gaia', version=2)
-            if 'designation' in catalogdata.colnames and 'DESIGNATION' not in catalogdata.colnames:
-                catalogdata.rename_column('designation', 'DESIGNATION')
-            print(f'Found {len(catalogdata)} Gaia objects from MAST fallback.')
+            try:
+                cone_columns = ', '.join(['DESIGNATION', 'phot_g_mean_mag', 'phot_bp_mean_mag',
+                                          'phot_rp_mean_mag', 'ra', 'dec', 'pmra', 'pmdec'])
+                row_limit = f"TOP {Gaia.ROW_LIMIT}" if Gaia.ROW_LIMIT > 0 else ""
+                cone_query = (
+                    f"SELECT {row_limit} {cone_columns}, "
+                    f"DISTANCE(POINT('ICRS', ra, dec), POINT('ICRS', {ra}, {dec})) AS dist "
+                    f"FROM {Gaia.MAIN_GAIA_TABLE} "
+                    f"WHERE 1 = CONTAINS(POINT('ICRS', ra, dec), "
+                    f"CIRCLE('ICRS', {ra}, {dec}, {radius.value})) ORDER BY dist ASC"
+                )
+                with _dot_wait(f'Querying Gaia via mirror TAP'):
+                    catalogdata = TapPlus(url=gaia_tap_server).launch_job_async(cone_query).get_results()
+                if 'designation' in catalogdata.colnames and 'DESIGNATION' not in catalogdata.colnames:
+                    catalogdata.rename_column('designation', 'DESIGNATION')
+                print(f'Found {len(catalogdata)} Gaia DR3 objects from mirror TAP.')
+            except Exception as exc2:
+                warnings.warn(
+                    f'Mirror Gaia TAP also failed ({exc2}). Falling back to MAST Gaia catalog (DR2).'
+                )
+                with _dot_wait('Querying Gaia catalog from MAST'):
+                    catalogdata = Catalogs.query_region(coord, radius=radius, catalog='Gaia', version=2)
+                if 'designation' in catalogdata.colnames and 'DESIGNATION' not in catalogdata.colnames:
+                    catalogdata.rename_column('designation', 'DESIGNATION')
+                print(f'Found {len(catalogdata)} Gaia objects from MAST fallback.')
         with _dot_wait('Querying TIC around target'):
             catalogdata_tic = tic_advanced_search_position_rows(
                 ra=ra,
@@ -165,7 +192,7 @@ class Source_cut(object):
             )
         print(f'Found {len(catalogdata_tic)} TIC objects.')
         with _dot_wait('Crossmatching TIC -> Gaia DR3 (this may take a while)'):
-            self.tic = convert_gaia_id(catalogdata_tic)
+            self.tic = convert_gaia_id(catalogdata_tic, gaia_tap_server=gaia_tap_server)
         sector_table = Tesscut.get_sectors(coordinates=coord)
         if len(sector_table) == 0:
             warnings.warn('TESS has not observed this position yet :(')
@@ -364,7 +391,7 @@ class Source_cut_pseudo(object):
 
 
 def ffi_cut(target='', local_directory='', size=90, sector=None, limit_mag=None, transient=None, ffi='TICA',
-            mast_timeout=3600):
+            mast_timeout=3600, gaia_tap_server="https://gea.esac.esa.int/tap-server/tap"):
     """
     Function to generate Source_cut objects
     :param target: string, required
@@ -394,6 +421,6 @@ def ffi_cut(target='', local_directory='', size=90, sector=None, limit_mag=None,
     else:
         with open(f'{local_directory}source/{source_name}.pkl', 'wb') as output:
             source = Source_cut(target, size=size, sector=sector, limit_mag=limit_mag, transient=transient, ffi=ffi,
-                                mast_timeout=mast_timeout)
+                                mast_timeout=mast_timeout, gaia_tap_server=gaia_tap_server)
             pickle.dump(source, output, pickle.HIGHEST_PROTOCOL)
     return source

--- a/tglc/quick_lc.py
+++ b/tglc/quick_lc.py
@@ -10,6 +10,7 @@ from multiprocessing import Pool
 from functools import partial
 from tglc.target_lightcurve import epsf
 from tglc.ffi_cut import ffi_cut, _dot_wait
+from astroquery.gaia import Gaia
 from astroquery.mast import Catalogs
 import astropy.units as u
 from astropy.coordinates import SkyCoord
@@ -32,7 +33,7 @@ controller = ThreadpoolController()
 @controller.wrap(limits=1, user_api='blas')
 def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True, limit_mag=16, get_all_lc=False,
             first_sector_only=False, last_sector_only=False, sector=None, prior=None, transient=None, ffi='SPOC',
-            mast_timeout=3600):
+            mast_timeout=3600, gaia_tap_server="https://gea.esac.esa.int/tap-server/tap"):
     '''
     Generate light curve for a single target.
 
@@ -114,14 +115,23 @@ def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True,
                 ).to_pandas()
                 if ticvals.shape[0] > 1:
                     ticvals = ticvals[ticvals.ID.astype(int).isin([TIC_ID])].reset_index(drop=True)
-                tmpgaiavals = TapPlus(url="https://gea.esac.esa.int/tap-server/tap").launch_job(
-                    "SELECT TOP 1 * FROM gaiadr3.dr2_neighbourhood WHERE dr2_source_id = {}".format(
-                        ticvals.loc[0, 'GAIA'])).get_results().to_pandas()
-                gaiavals = TapPlus(url="https://gea.esac.esa.int/tap-server/tap").launch_job(
-                    "SELECT TOP 1 * FROM gaiadr3.gaia_source WHERE source_id = {}".format(
-                        tmpgaiavals.loc[0, 'dr3_source_id'])).get_results().to_pandas()
-            dr2_id = tmpgaiavals.loc[0, 'dr2_source_id']
-            dr3_designation = gaiavals.loc[0, 'designation'.upper()]
+                join_query = (
+                    "SELECT dr3.*, dr2.dr2_source_id FROM {0}.gaia_source AS dr3 "
+                    "INNER JOIN {0}.dr2_neighbourhood AS dr2 "
+                    "ON dr3.source_id = dr2.dr3_source_id "
+                    "WHERE dr2.dr2_source_id = {1}"
+                ).format(Gaia.MAIN_GAIA_TABLE.split('.')[0], ticvals.loc[0, 'GAIA'])
+                try:
+                    gaiavals = Gaia.launch_job(join_query).get_results().to_pandas()
+                except Exception as exc:
+                    warnings.warn(
+                        f'Primary Gaia TAP DR2->DR3 lookup failed ({exc}). Retrying via mirror {gaia_tap_server}.'
+                    )
+                    gaiavals = TapPlus(url=gaia_tap_server).launch_job(join_query).get_results().to_pandas()
+                if 'DESIGNATION' not in gaiavals.columns and 'designation' in gaiavals.columns:
+                    gaiavals['DESIGNATION'] = gaiavals['designation'].values
+            dr2_id = gaiavals.loc[0, 'dr2_source_id']
+            dr3_designation = gaiavals.loc[0, 'DESIGNATION']
             print(f'DR2 source_id: {dr2_id}; DR3 designation: {dr3_designation}')
             name = f'{dr3_designation}'
         elif transient is not None:
@@ -140,7 +150,8 @@ def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True,
         print('Downloading data from MAST and Gaia.')
         print(f'MAST Tesscut timeout set to {mast_timeout}s.')
         source = ffi_cut(target=target, size=size, local_directory=local_directory, sector=sector,
-                         limit_mag=limit_mag, transient=transient, ffi=ffi, mast_timeout=mast_timeout)  # sector
+                         limit_mag=limit_mag, transient=transient, ffi=ffi, mast_timeout=mast_timeout,
+                         gaia_tap_server=gaia_tap_server)  # sector
         source.select_sector(sector=sector)
         epsf(source, factor=2, sector=source.sector, target=target, local_directory=local_directory,
              name=name, limit_mag=limit_mag, save_aper=save_aper, prior=prior, ffi=ffi)
@@ -150,7 +161,8 @@ def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True,
         print(f'MAST Tesscut timeout set to {mast_timeout}s.')
         sector = sector_table["sector"][0]
         source = ffi_cut(target=target, size=size, local_directory=local_directory, sector=sector,
-                         limit_mag=limit_mag, transient=transient, ffi=ffi, mast_timeout=mast_timeout)  # sector
+                         limit_mag=limit_mag, transient=transient, ffi=ffi, mast_timeout=mast_timeout,
+                         gaia_tap_server=gaia_tap_server)  # sector
         source.select_sector(sector=source.sector_table['sector'][0])
         epsf(source, factor=2, sector=source.sector, target=target, local_directory=local_directory,
              name=name, limit_mag=limit_mag, save_aper=save_aper, prior=prior, ffi=ffi)
@@ -160,7 +172,8 @@ def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True,
         print(f'MAST Tesscut timeout set to {mast_timeout}s.')
         sector = sector_table["sector"][-1]
         source = ffi_cut(target=target, size=size, local_directory=local_directory, sector=sector,
-                         limit_mag=limit_mag, transient=transient, ffi=ffi, mast_timeout=mast_timeout)  # sector
+                         limit_mag=limit_mag, transient=transient, ffi=ffi, mast_timeout=mast_timeout,
+                         gaia_tap_server=gaia_tap_server)  # sector
         source.select_sector(sector=source.sector_table['sector'][-1])
         epsf(source, factor=2, sector=source.sector, target=target, local_directory=local_directory,
              name=name, limit_mag=limit_mag, save_aper=save_aper, prior=prior, ffi=ffi)
@@ -173,7 +186,8 @@ def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True,
             print(f'Downloading Sector {sector_table["sector"][j]} (product={ffi}).')
             source = ffi_cut(target=target, size=size, local_directory=local_directory,
                              sector=sector_table['sector'][j],
-                             limit_mag=limit_mag, transient=transient, ffi=ffi, mast_timeout=mast_timeout)
+                             limit_mag=limit_mag, transient=transient, ffi=ffi, mast_timeout=mast_timeout,
+                             gaia_tap_server=gaia_tap_server)
             epsf(source, factor=2, sector=source.sector, target=target, local_directory=local_directory,
                  name=name, limit_mag=limit_mag, save_aper=save_aper, prior=prior, ffi=ffi)
     else:
@@ -183,7 +197,8 @@ def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True,
         print('Downloading data from MAST and Gaia.')
         print(f'MAST Tesscut timeout set to {mast_timeout}s.')
         source = ffi_cut(target=target, size=size, local_directory=local_directory, sector=sector,
-                         limit_mag=limit_mag, transient=transient, ffi=ffi, mast_timeout=mast_timeout)  # sector
+                         limit_mag=limit_mag, transient=transient, ffi=ffi, mast_timeout=mast_timeout,
+                         gaia_tap_server=gaia_tap_server)  # sector
         for j in range(len(source.sector_table)):
             source.select_sector(sector=source.sector_table['sector'][j])
             epsf(source, factor=2, sector=source.sector, target=target, local_directory=local_directory,


### PR DESCRIPTION
## Summary
- Adds a `gaia_tap_server` parameter threaded through `tglc_lc`, `ffi_cut`, `Source_cut`, and `convert_gaia_id`. On primary Gaia TAP failure, queries retry against the user-specified mirror before falling back to the MAST Gaia / TIC-GAIA DR2 safety nets.
- Collapses the DR2→DR3 designation lookup in `quick_lc` to a single `gaia_source` ⨝ `dr2_neighbourhood` JOIN (drops the intermediate `tmpgaiavals` roundtrip).
- Guards `tesscube` import with `try/except ImportError`.
- Credit: Caleb Cañas (@cicanas) — upstreams the mirror idea and simplified JOIN from `cicanas/TESS_Gaia_Light_Curve@develop`.

## Test plan
- [x] Single-sector smoketest: `TIC 16005254`, sector 44, size 50, SPOC → LC FITS + ePSF npy + source pickle written; DR2→DR3 JOIN 3.0s, cone search 4.4s, crossmatch 3.3s.
- [ ] Reviewer sanity: confirm default `gaia_tap_server="https://gea.esac.esa.int/tap-server/tap"` is the right baseline (same server astroquery.gaia uses).
- [ ] Post-merge: tag `v0.7.2`, GitHub release, build + upload to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)