### PR TITLE
0.7.3: fix int-TIC regression from 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.3
+- Fix regression from 0.7.2: `tglc_lc(target=<int>)` and `ffi_cut(target=<int>)` raised because `Catalogs.query_object` rejects bare integers. Integer TIC IDs are now accepted by `_is_tic_id` / `_parse_tic_id` and wrapped as `f'TIC {id}'` before any MAST call, matching the `'TIC N'` string path end-to-end (same DR3 designation filename).
+
 ## 0.7.2
 - Added a configurable `gaia_tap_server` parameter to `tglc_lc`, `ffi_cut`, `Source_cut`, and `convert_gaia_id` so Gaia TAP queries can fall back to a user-specified mirror when the primary ESA server is down. Credit: Caleb Cañas (@cicanas).
 - `convert_gaia_id` now retries each 10k-ID batch against the mirror before giving up and using the TIC-GAIA (DR2) fallback.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 setuptools.setup(
     name="tglc",
-    version='0.7.2',
+    version='0.7.3',
     author="Te Han",
     author_email="tehanhunter@gmail.com",
     description="TESS-Gaia Light Curve",

--- a/tglc/ffi_cut.py
+++ b/tglc/ffi_cut.py
@@ -99,6 +99,8 @@ class Source_cut(object):
         print(f'MAST Tesscut timeout set to {mast_timeout}s.')
 
         def _parse_tic_id(t):
+            if isinstance(t, (int, np.integer)):
+                return int(t)
             if not isinstance(t, str):
                 return None
             s = t.strip()
@@ -110,6 +112,8 @@ class Source_cut(object):
             return int(s) if s.isdigit() else None
 
         def _is_tic_id(t):
+            if isinstance(t, (int, np.integer)):
+                return True
             if not isinstance(t, str):
                 return False
             s = t.strip()
@@ -117,14 +121,15 @@ class Source_cut(object):
 
         target = None
         is_tic = _is_tic_id(self.name) and _parse_tic_id(self.name) is not None
+        mast_name = f'TIC {_parse_tic_id(self.name)}' if is_tic else self.name
         try:
-            target = Catalogs.query_object(self.name, radius=21 * 0.707 / 3600, catalog="Gaia", version=2)
+            target = Catalogs.query_object(mast_name, radius=21 * 0.707 / 3600, catalog="Gaia", version=2)
         except requests.exceptions.RequestException as e:
             warnings.warn(f'MAST name lookup failed for "{self.name}": {e}')
 
         if target is None or len(target) == 0:
             try:
-                target = Catalogs.query_object(self.name, radius=5 * 21 * 0.707 / 3600, catalog="Gaia", version=2)
+                target = Catalogs.query_object(mast_name, radius=5 * 21 * 0.707 / 3600, catalog="Gaia", version=2)
             except requests.exceptions.RequestException as e:
                 warnings.warn(f'MAST name lookup failed for "{self.name}": {e}')
 

--- a/tglc/quick_lc.py
+++ b/tglc/quick_lc.py
@@ -56,6 +56,8 @@ def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True,
         warnings.warn('TICA support is experimental; Tesscut product availability may be limited.')
 
     def _parse_tic_id(t):
+        if isinstance(t, (int, np.integer)):
+            return int(t)
         if not isinstance(t, str):
             return None
         s = t.strip()
@@ -66,6 +68,8 @@ def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True,
             s = s[3:].strip()
         return int(s) if s.isdigit() else None
     def _is_tic_id(t):
+        if isinstance(t, (int, np.integer)):
+            return True
         if not isinstance(t, str):
             return False
         s = t.strip()
@@ -74,8 +78,9 @@ def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True,
     radius_deg = 42 * 0.707 / 3600
     target_ = None
     is_tic = _is_tic_id(target) and _parse_tic_id(target) is not None
+    mast_target = f'TIC {_parse_tic_id(target)}' if is_tic else target
     try:
-        target_ = Catalogs.query_object(target, radius=radius_deg, catalog="Gaia", version=2)
+        target_ = Catalogs.query_object(mast_target, radius=radius_deg, catalog="Gaia", version=2)
     except requests.exceptions.RequestException as e:
         warnings.warn(f'MAST name lookup failed for "{target}": {e}')
 
@@ -106,7 +111,7 @@ def tglc_lc(target='TIC 264468702', local_directory='', size=90, save_aper=True,
         name = None
     else:
         if is_tic:
-            TIC_ID = int(target.strip().split()[-1])
+            TIC_ID = _parse_tic_id(target)
             with _dot_wait('Resolving TIC -> Gaia DR3 designation via TAP'):
                 ticvals = Catalogs.query_object(
                     f'TIC {TIC_ID}',


### PR DESCRIPTION
## Summary
**Regression fix** — in 0.7.2, `tglc_lc(target=<int>)` and `ffi_cut(target=<int>)` raise because `Catalogs.query_object` rejects bare integers. Downstream agents hit this on production runs (e.g. `target=60764070`).

- `_is_tic_id` / `_parse_tic_id` (in both `quick_lc.tglc_lc` and `ffi_cut.Source_cut.__init__`) now accept `int` and `np.integer` inputs.
- MAST name lookups format `f'TIC {id}'` whenever `is_tic` is True.
- Integer and string TIC inputs now produce identical Gaia DR3 designation filenames.

## Test plan
- [x] `_parse_tic_id` returns the same int for `16005254` / `'16005254'` / `'TIC 16005254'` / `np.int64(16005254)`, and `None` for `'M31'`.
- [ ] Reviewer: sanity-check that the `f'TIC {id}'` wrapping doesn't change behavior for existing string-form calls.
- [ ] Post-merge: tag `v0.7.3`, GitHub release, build + upload to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)